### PR TITLE
Fix install/uninstall framework with parent on android

### DIFF
--- a/cordova-lib/spec-plugman/platforms/android.spec.js
+++ b/cordova-lib/spec-plugman/platforms/android.spec.js
@@ -180,7 +180,7 @@ describe('android project handler', function() {
             android['framework'].install(frameworkElement, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0'});
             android.parseProjectFile(temp).write();
 
-            // exec doesn't get called since plugin dir doesn't actually exist.
+            // exec doesn't get called since sublibrary dir doesn't actually exist.
             expect(exec).not.toHaveBeenCalled();
             var finalProjectProperties = fs.readFileSync(mainProjectPropsFile, 'utf8');
             expect(finalProjectProperties).toMatch('\nandroid.library.reference.3=' + '../SDK/extras/android/support/v4', 'Sublibrary not added');
@@ -212,6 +212,77 @@ describe('android project handler', function() {
 
             finalProjectProperties = fs.readFileSync(mainProjectPropsFile, 'utf8');
             expect(finalProjectProperties).not.toMatch('\ncordova.system.library.1=' + 'extras/android/support/v4', 'Sublibrary not added');
+        });
+        it('with custom=true and parent', function () {
+            var packageIdSuffix = 'childapp';
+            var frameworkElement = { src: 'plugin-lib', custom: true };
+            var frameworkElementChild = { src: 'plugin-lib2', custom: true, parent: 'plugin-lib' };
+            var parentDir = path.resolve(temp, dummy_id, packageIdSuffix + '-' + frameworkElementChild.parent);
+            var parentProjectPropsFile = path.resolve(parentDir, 'project.properties');
+            var subDir = path.resolve(temp, dummy_id, packageIdSuffix + '-' + frameworkElement.src);
+            var subProjectPropsFile = path.resolve(subDir, 'project.properties');
+
+            var exec = spyOn(shell, 'exec');
+
+            android['framework'].install(frameworkElement, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+            android['framework'].install(frameworkElementChild, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+
+            var finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            expect(finalProjectProperties).toMatch('\nandroid.library.reference.1=../' + packageIdSuffix + '-plugin-lib2', 'Reference to library not added');
+            var subProjectProperties = fs.readFileSync(subProjectPropsFile, 'utf8');
+            expect(subProjectProperties).toMatch(/\btarget=android-19$/m, 'target SDK version not copied to library');
+            expect(exec).toHaveBeenCalledWith('android update lib-project --path "' + subDir + '"');
+
+            // Now test uninstall
+            android.purgeProjectFileCache(temp);
+            android['framework'].uninstall(frameworkElementChild, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+
+            finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            expect(finalProjectProperties).not.toMatch('\nandroid.library.reference.1=../' + packageIdSuffix + '-plugin-lib2', 'Reference to library not removed');
+
+            android['framework'].uninstall(frameworkElement, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+
+            expect(fs.existsSync(subDir)).toBe(false, 'Should delete subdir');
+        });
+        it('with custom=false and parent', function () {
+            var packageIdSuffix = 'childapp';
+            var frameworkElement = { src: 'plugin-lib', custom: true };
+            var frameworkElementChild = { src: 'extras/android/support/v4', custom: false, parent: 'plugin-lib' };
+            var parentDir = path.resolve(temp, dummy_id, packageIdSuffix + '-' + frameworkElementChild.parent);
+            var parentProjectPropsFile = path.resolve(parentDir, 'project.properties');
+            var sdkLibRelativeDir = path.join('..', 'SDK', 'extras', 'android', 'support', 'v4');
+            var exec = spyOn(shell, 'exec');
+
+            android['framework'].install(frameworkElement, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+            fs.writeFileSync(path.join(parentDir, 'local.properties'), 'sdk.dir=' + path.join(temp, '..', 'SDK').replace(/\\/g, '/'));
+            android['framework'].install(frameworkElementChild, dummyplugin, temp, dummy_id, { platformVersion: '3.0.0' });
+
+            android.parseProjectFile(temp).write();
+            android.parseProjectFile(parentDir).write();
+
+            exec.reset();
+
+            var finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            var libReference = '\nandroid.library.reference.1=' + path.join('..', '..', sdkLibRelativeDir).replace(/\\/g, '/');
+            expect(finalProjectProperties).toMatch(libReference, 'Reference to library not added');
+            // exec doesn't get called since sublibrary dir doesn't actually exist.
+            expect(exec).not.toHaveBeenCalled();
+
+            // Now test uninstall
+            android.purgeProjectFileCache(temp);
+            android.purgeProjectFileCache(parentDir);
+            android['framework'].uninstall(frameworkElementChild, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
+            android.parseProjectFile(parentDir).write();
+
+            finalProjectProperties = fs.readFileSync(parentProjectPropsFile, 'utf8');
+            expect(finalProjectProperties).not.toMatch(libReference, 'Reference to library not removed');
+
+            android['framework'].uninstall(frameworkElement, temp, dummy_id, { platformVersion: '3.0.0' });
+            android.parseProjectFile(temp).write();
         });
     });
     describe('uninstallation', function() {

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/AndroidManifest.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  android:versionCode="1" package="com.test.somelib2">
+    <uses-sdk android:minSdkVersion="9"/>
+    <application/>
+</manifest>

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/libFile
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/libFile
@@ -1,0 +1,1 @@
+libFile contents

--- a/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/project.properties
+++ b/cordova-lib/spec-plugman/plugins/org.test.plugins.dummyplugin/plugin-lib2/project.properties
@@ -1,0 +1,1 @@
+target=android-11

--- a/cordova-lib/src/plugman/platforms/android.js
+++ b/cordova-lib/src/plugman/platforms/android.js
@@ -122,7 +122,10 @@ module.exports = {
 
             events.emit('verbose', 'Installing Android library: ' + src);
             var parent = obj.parent;
-            var parentDir = parent ? path.resolve(project_dir, parent) : project_dir;
+            var parentDir = parent ?
+                    path.resolve(project_dir, getCustomSubprojectRelativeDir(plugin_id, project_dir, parent)) :
+                    project_dir;
+
             var subDir;
             var type = obj.type;
 
@@ -135,7 +138,7 @@ module.exports = {
                     type = 'sys';
                     subDir = src;
                 } else {
-                    var sdk_dir = getProjectSdkDir(project_dir);
+                    var sdk_dir = getProjectSdkDir(parentDir);
                     subDir = path.resolve(sdk_dir, src);
                 }
             }
@@ -157,7 +160,9 @@ module.exports = {
 
             events.emit('verbose', 'Uninstalling Android library: ' + src);
             var parent = obj.parent;
-            var parentDir = parent ? path.resolve(project_dir, parent) : project_dir;
+            var parentDir = parent ?
+                    path.resolve(project_dir, getCustomSubprojectRelativeDir(plugin_id, project_dir, parent)) :
+                    project_dir;
             var subDir;
             var type = obj.type;
 
@@ -175,7 +180,7 @@ module.exports = {
                     type = 'sys';
                     subDir = src;
                 } else {
-                    var sdk_dir = getProjectSdkDir(project_dir);
+                    var sdk_dir = getProjectSdkDir(parentDir);
                     subDir = path.resolve(sdk_dir, src);
                 }
             }


### PR DESCRIPTION
- Correct parentDir value when parent != null
- Fix sdk_dir to be relative to parentDir
- Add a second lib ion dummyplugin
- Add unit test

@Icenium/core 

Fixes [Feedback plugin installation fails on SIT](http://teampulse.telerik.com/view#item/296913)
