### PR TITLE
Pass project_dir instead of parentDir when resolving sdk directory

### DIFF
--- a/cordova-lib/src/plugman/platforms/android.js
+++ b/cordova-lib/src/plugman/platforms/android.js
@@ -138,7 +138,11 @@ module.exports = {
                     type = 'sys';
                     subDir = src;
                 } else {
-                    var sdk_dir = getProjectSdkDir(parentDir);
+                    // TODO: pass parentDir along with project_dir
+                    // to try and get the sdk dir - if it's not in the parent's local.properties
+                    // look for it in project's local.properties
+                    // if it's not there either check ANDROID_HOME env variable
+                    var sdk_dir = getProjectSdkDir(project_dir);
                     subDir = path.resolve(sdk_dir, src);
                 }
             }


### PR DESCRIPTION
When resolving the sdk directory a framework should look inside its parent's local.properties file, however we save the project after installing **ALL** of the plugins, so at the time of installation, the parent does not yet have a local.properties file.
Instead resolve the sdk directory directly from the project's local.properties until a better way is found.
Ping @Icenium/core 
