### PR TITLE
CB-7015 Add support for parent and custom attributes in lib-file element

### DIFF
--- a/cordova-lib/spec-plugman/platforms/android.spec.js
+++ b/cordova-lib/spec-plugman/platforms/android.spec.js
@@ -27,6 +27,7 @@ var android = require('../../src/plugman/platforms/android'),
     os      = require('osenv'),
     temp    = path.join(os.tmpdir(), 'plugman'),
     plugins_dir = path.join(temp, 'cordova', 'plugins'),
+    androidonlyplugin = path.join(__dirname, '..', 'plugins', 'org.test.androidonly'),
     dummyplugin = path.join(__dirname, '..', 'plugins', 'org.test.plugins.dummyplugin'),
     faultyplugin = path.join(__dirname, '..', 'plugins', 'org.test.plugins.faultyplugin'),
     android_one_project = path.join(__dirname, '..', 'projects', 'android_one', '*'),
@@ -35,10 +36,11 @@ var android = require('../../src/plugman/platforms/android'),
 var PluginInfo = require('../../src/PluginInfo');
 
 var dummyPluginInfo = new PluginInfo(dummyplugin);
+var androidonlyPluginInfo = new PluginInfo(androidonlyplugin);
 var dummy_id = dummyPluginInfo.id;
 var valid_source = dummyPluginInfo.getSourceFiles('android'),
     valid_resources = dummyPluginInfo.getResourceFiles('android'),
-    valid_libs = dummyPluginInfo.getLibFiles('android');
+    valid_libs = androidonlyPluginInfo.getLibFiles('android');
 
 var faultyPluginInfo = new PluginInfo(faultyplugin);
 var invalid_source = faultyPluginInfo.getSourceFiles('android');
@@ -48,6 +50,10 @@ function copyArray(arr) {
 }
 
 describe('android project handler', function() {
+    afterEach(function() {
+        shell.rm('-rf', temp);
+        android.purgeProjectFileCache(temp);
+    });
     describe('www_dir method', function() {
         it('should return cordova-android project www location using www_dir', function() {
             expect(android.www_dir(path.sep)).toEqual(path.sep + path.join('assets', 'www'));
@@ -63,15 +69,38 @@ describe('android project handler', function() {
         beforeEach(function() {
             shell.mkdir('-p', temp);
         });
-        afterEach(function() {
-            shell.rm('-rf', temp);
-        });
         describe('of <lib-file> elements', function() {
             it('should copy jar files to project/libs', function () {
                 var s = spyOn(common, 'copyFile');
 
                 android['lib-file'].install(valid_libs[0], dummyplugin, temp);
                 expect(s).toHaveBeenCalledWith(dummyplugin, 'src/android/TestLib.jar', temp, path.join('libs', 'TestLib.jar'), false);
+            });
+        });
+        describe('of <lib-file> elements with custom=false', function() {
+            it('should copy jar files from sdk directory to project/libs', function () {
+                var s = spyOn(common, 'copyFile');
+                var localProjectPropsFile = path.resolve(temp, 'local.properties');
+                var sdkDir = path.join(temp, '..', 'SDK').replace(/\\/g, '/');
+                fs.writeFileSync(localProjectPropsFile, 'sdk.dir=' + sdkDir);
+
+                android['lib-file'].install(valid_libs[1], androidonlyplugin, temp, androidonlyPluginInfo.id);
+                expect(s).toHaveBeenCalledWith(sdkDir, 'extras/android/support/v4/android-support-v4.jar', temp, path.join('libs', 'android-support-v4.jar'), false);
+            });
+        });
+        describe('of <lib-file> elements with parent', function() {
+            it('should copy jar files to sub-project/libs', function () {
+                shell.cp('-rf', android_one_project, temp);
+                var s = spyOn(common, 'copyFile');
+                var localProjectPropsFile = path.resolve(temp, 'local.properties');
+                var sdkDir = path.join(temp, '..', 'SDK').replace(/\\/g, '/');
+                fs.writeFileSync(localProjectPropsFile, 'sdk.dir=' + sdkDir);
+
+                android['lib-file'].install(valid_libs[2], androidonlyplugin, temp, androidonlyPluginInfo.id);
+                expect(s).toHaveBeenCalledWith(
+                    sdkDir, 'extras/android/support/v4/android-support-v4.jar',
+                    path.resolve(temp, androidonlyPluginInfo.id, 'childapp-plugin-lib'),
+                    path.join('libs', 'android-support-v4.jar'), false);
             });
         });
         describe('of <resource-file> elements', function() {
@@ -117,10 +146,6 @@ describe('android project handler', function() {
     describe('<framework> elements', function() {
         beforeEach(function() {
             shell.cp('-rf', android_one_project, temp);
-        });
-        afterEach(function() {
-            shell.rm('-rf', temp);
-            android.purgeProjectFileCache(temp);
         });
         it('with custom=true', function() {
             var packageIdSuffix = 'childapp';
@@ -290,9 +315,6 @@ describe('android project handler', function() {
             shell.mkdir('-p', temp);
             shell.mkdir('-p', plugins_dir);
             shell.cp('-rf', android_two_project, temp);
-        });
-        afterEach(function() {
-            shell.rm('-rf', temp);
         });
         describe('of <lib-file> elements', function(done) {
             it('should remove jar files', function () {

--- a/cordova-lib/spec-plugman/plugins/org.test.androidonly/plugin.xml
+++ b/cordova-lib/spec-plugman/plugins/org.test.androidonly/plugin.xml
@@ -30,5 +30,11 @@
         <js-module src="www/android.js" name="Android">
             <clobbers target="android" />
         </js-module>
+
+        <framework src="plugin-lib" custom="true" />
+
+        <lib-file src="src/android/TestLib.jar" />
+        <lib-file src="extras/android/support/v4/android-support-v4.jar" custom="false" />
+        <lib-file src="extras/android/support/v4/android-support-v4.jar" custom="false" parent="plugin-lib" />
     </platform>
 </plugin>

--- a/cordova-lib/src/PluginInfo.js
+++ b/cordova-lib/src/PluginInfo.js
@@ -211,6 +211,8 @@ function PluginInfo(dirname) {
             return {
                 itemType: 'lib-file',
                 src: tag.attrib.src,
+                parent: tag.attrib.parent,
+                custom: !isStrFalse(tag.attrib.custom), // default to true if not set
                 arch: tag.attrib.arch,
                 Include: tag.attrib.Include,
                 versions: tag.attrib.versions,
@@ -382,7 +384,12 @@ function _getTagsInPlatform(pelem, tag, platform, transform) {
 
 // Check if x is a string 'true'.
 function isStrTrue(x) {
-    return String(x).toLowerCase() == 'true';
+    return String(x).toLowerCase() === 'true';
+}
+
+// Check if x is a string 'false'.
+function isStrFalse(x) {
+    return String(x).toLowerCase() === 'false';
 }
 
 module.exports = PluginInfo;

--- a/cordova-lib/src/plugman/platforms/android.js
+++ b/cordova-lib/src/plugman/platforms/android.js
@@ -93,13 +93,19 @@ module.exports = {
     'lib-file':{
         install:function(obj, plugin_dir, project_dir, plugin_id, options) {
             var src = obj.src;
+            var custom = obj.custom;
+            var parent = obj.parent;
+            var src_dir = custom ? plugin_dir : getProjectSdkDir(project_dir);
+            var dest_dir = obj.parent ? path.resolve(project_dir, getCustomSubprojectRelativeDir(plugin_id, project_dir, parent)) : project_dir;
             var dest = path.join('libs', path.basename(src));
-            common.copyFile(plugin_dir, src, project_dir, dest, !!(options && options.link));
+            common.copyFile(src_dir, src, dest_dir, dest, !!(options && options.link));
         },
         uninstall:function(obj, project_dir, plugin_id, options) {
             var src = obj.src;
+            var parent = obj.parent;
             var dest = path.join('libs', path.basename(src));
-            common.removeFile(project_dir, dest);
+            var dest_dir = obj.parent ? path.resolve(project_dir, getCustomSubprojectRelativeDir(plugin_id, project_dir, parent)) : project_dir;
+            common.removeFile(dest_dir, dest);
         }
     },
     'resource-file':{


### PR DESCRIPTION
This enables referring to libraries from the Android SDK directory.

refs: [[plugman] Support copying jars from Android SDK](http://teampulse.telerik.com/view#item/297388)

Update cordova-plugman SHA and BpcTooling SHA after merging
