### PR TITLE
Overwrite destination in copyFile with symlinks

### DIFF
--- a/cordova-lib/spec-plugman/platforms/common.spec.js
+++ b/cordova-lib/spec-plugman/platforms/common.spec.js
@@ -82,6 +82,38 @@ describe('common platform handler', function() {
             shell.rm('-rf', project_dir);
         });
 
+        it('should overwrite dest', function(){
+            shell.mkdir('-p', java_dir);
+            fs.writeFileSync(dest, 'contents-old', 'utf-8');
+            fs.writeFileSync(java_file, 'contents-new', 'utf-8');
+
+            // This will fail on windows if not admin - ignore the error in that case.
+            if (ignoreEPERMonWin32(java_file, symlink_file)) {
+                return;
+            }
+
+            common.copyFile(test_dir, symlink_file, project_dir, dest);
+            expect(fs.readFileSync(dest, 'utf-8')).toBe('contents-new');
+            shell.rm('-rf', project_dir);
+        });
+
+        it('should overwrite dest when symlinking', function(){
+            shell.mkdir('-p', java_dir);
+            fs.writeFileSync(dest, 'contents-old', 'utf-8');
+            fs.writeFileSync(java_file, 'contents-new', 'utf-8');
+
+            // This will fail on windows if not admin - ignore the error in that case.
+            if (ignoreEPERMonWin32(java_file, symlink_file)) {
+                return;
+            }
+
+            var create_symlink = true;
+            common.copyFile(test_dir, symlink_file, project_dir, dest, create_symlink);
+            expect(fs.readFileSync(dest, 'utf-8')).toBe('contents-new');
+            expect(path.resolve(path.dirname(dest), fs.readlinkSync(dest))).toBe(path.resolve(symlink_file));
+            shell.rm('-rf', project_dir);
+        });
+
         it('should throw if symlink is linked to a file outside the plugin', function(){
             shell.mkdir('-p', java_dir);
             fs.writeFileSync(non_plugin_file, 'contents', 'utf-8');

--- a/cordova-lib/src/plugman/platforms/common.js
+++ b/cordova-lib/src/plugman/platforms/common.js
@@ -52,6 +52,9 @@ module.exports = common = {
         shell.mkdir('-p', path.dirname(dest));
 
         if (link) {
+            if (fs.existsSync(dest)) {
+                fs.unlinkSync(dest);
+            }
             fs.symlinkSync(path.relative(fs.realpathSync(path.dirname(dest)), src), dest);
         } else if (fs.statSync(src).isDirectory()) {
             // XXX shelljs decides to create a directory when -R|-r is used which sucks. http://goo.gl/nbsjq


### PR DESCRIPTION
copyFile should behave consistently when using symlinking and when actually copying the file.
Since fs.symlinkSys throws an error when the destination exists, we now check and delete the file if it is already present.

This bug blocks us from using `lib-file` support for referencing Android SDK jars, because two plugins depending on the same library cannot be successfully installed.

ping @Icenium/core 
