### PR TITLE
CB-11771 Deep symlink directories to target project instead of linking the directory itself

### DIFF
--- a/cordova-lib/spec-plugman/platforms/common.spec.js
+++ b/cordova-lib/spec-plugman/platforms/common.spec.js
@@ -30,6 +30,8 @@ var common = require('../../src/plugman/platforms/common')
   , java_dir = path.join(src, 'one', 'two', 'three')
   , java_file = path.join(java_dir, 'test.java')
   , symlink_file = path.join(java_dir, 'symlink')
+  , symlink_dir = path.join(java_dir, 'symlink_dir')
+  , symlink_dir_relative_file = path.join('one', 'two', 'file')
   , non_plugin_file = path.join(osenv.tmpdir(), 'non_plugin_file');
 
 describe('common platform handler', function() {
@@ -111,6 +113,24 @@ describe('common platform handler', function() {
             common.copyFile(test_dir, symlink_file, project_dir, dest, create_symlink);
             expect(fs.readFileSync(dest, 'utf-8')).toBe('contents-new');
             expect(path.resolve(path.dirname(dest), fs.readlinkSync(dest))).toBe(path.resolve(symlink_file));
+            shell.rm('-rf', project_dir);
+        });
+
+        it('should deeply symlink directory tree when src is a directory', function(){
+            var symlink_dir_relative_subdir = path.dirname(symlink_dir_relative_file);
+
+            shell.mkdir('-p', path.join(symlink_dir, symlink_dir_relative_subdir));
+            fs.writeFileSync(path.join(symlink_dir, symlink_dir_relative_file), 'contents', 'utf-8');
+
+            // This will fail on windows if not admin - ignore the error in that case.
+            if (ignoreEPERMonWin32(java_file, symlink_file)) {
+                return;
+            }
+
+            var create_symlink = true;
+            common.copyFile(test_dir, symlink_dir, project_dir, dest, create_symlink);
+
+            expect(path.resolve(dest, symlink_dir_relative_subdir, fs.readlinkSync(path.join(dest, symlink_dir_relative_file)))).toBe(path.resolve(symlink_dir, symlink_dir_relative_file));
             shell.rm('-rf', project_dir);
         });
 

--- a/cordova-lib/src/plugman/platforms/common.js
+++ b/cordova-lib/src/plugman/platforms/common.js
@@ -84,10 +84,7 @@ module.exports = common = {
         shell.mkdir('-p', path.dirname(dest));
 
         if (link) {
-            if (fs.existsSync(dest)) {
-                fs.unlinkSync(dest);
-            }
-            fs.symlinkSync(path.relative(fs.realpathSync(path.dirname(dest)), src), dest);
+            common.symlinkFileOrDirTree(src, dest);
         } else if (fs.statSync(src).isDirectory()) {
             // XXX shelljs decides to create a directory when -R|-r is used which sucks. http://goo.gl/nbsjq
             shell.cp('-Rf', src+'/*', dest);
@@ -102,6 +99,21 @@ module.exports = common = {
             throw new Error('"' + target_path + '" already exists!');
 
         common.copyFile(plugin_dir, src, project_dir, dest, !!link);
+    },
+    symlinkFileOrDirTree:function symlinkFileOrDirTree(src, dest) {
+            if (fs.existsSync(dest)) {
+                shell.rm('-Rf', dest);
+            }
+            
+            if (fs.statSync(src).isDirectory()) {
+                shell.mkdir('-p', dest);
+                fs.readdirSync(src).forEach(function(entry) {
+                    symlinkFileOrDirTree(path.join(src, entry), path.join(dest, entry));
+                });
+            }
+            else {
+                fs.symlinkSync(path.relative(fs.realpathSync(path.dirname(dest)), src), dest);
+            }
     },
     // checks if file exists and then deletes. Error if doesn't exist
     removeFile:function(project_dir, src) {


### PR DESCRIPTION
When installing a plugin with custom library using the --link option the whole directory is symlinked and temporary
files leak into the original plugin directory on build. This leads to broken builds if the same plugin is linked in
2 projects targeting different Cordova versions.
